### PR TITLE
Allow getting managed instance details

### DIFF
--- a/iam.tf
+++ b/iam.tf
@@ -6,6 +6,7 @@ resource "google_organization_iam_custom_role" "expel_k8s_role" {
   title       = var.iam_role_name
   description = "Grants read-only access to non-sensitive Kubernetes resources"
   permissions = [
+    "compute.instanceGroupManagers.get",
     "container.apiServices.get",
     "container.apiServices.getStatus",
     "container.apiServices.list",
@@ -180,6 +181,7 @@ resource "google_project_iam_custom_role" "expel_k8s_role" {
   title       = var.iam_role_name
   description = "Grants read-only access to non-sensitive Kubernetes resources"
   permissions = [
+    "compute.instanceGroupManagers.get",
     "container.apiServices.get",
     "container.apiServices.getStatus",
     "container.apiServices.list",


### PR DESCRIPTION
Added IAM permission `compute.instanceGroupManagers.get` so the Expel integration can inventory the managed instances for GKE clusters.