### PR TITLE
Corrected module output to match onboarding guide.

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -1,6 +1,6 @@
 output "pubsub_subscription_name" {
-  description = "Name of the Kinesis data stream Expel will consume from"
-  value       = google_pubsub_topic.expel_pubsub_topic.name
+  description = "Name of the pub/sub subscription Expel will consume from"
+  value       = "projects/${var.project_id}/subscriptions/${google_pubsub_subscription.expel_pubsub_subscription.name}"
 }
 
 output "service_account_key" {
@@ -8,3 +8,4 @@ output "service_account_key" {
   value       = google_service_account_key.expel_svc_acct_key.private_key
   sensitive   = true
 }
+


### PR DESCRIPTION
The current terraform module output produces the topic name instead of the subscription name used for workbench onboarding. This update changes that output value.